### PR TITLE
refactor: add a ValidateOnly version of composeXxxRelationship function for Issue hierarchy

### DIFF
--- a/server/issue.go
+++ b/server/issue.go
@@ -331,6 +331,58 @@ func (s *Server) composeIssueRelationship(ctx context.Context, issue *api.Issue)
 	return nil
 }
 
+func (s *Server) composeIssueRelationshipValidateOnly(ctx context.Context, issue *api.Issue) error {
+	var err error
+
+	issue.Creator, err = s.composePrincipalByID(ctx, issue.CreatorID)
+	if err != nil {
+		return err
+	}
+
+	issue.Updater, err = s.composePrincipalByID(ctx, issue.UpdaterID)
+	if err != nil {
+		return err
+	}
+
+	issue.Assignee, err = s.composePrincipalByID(ctx, issue.AssigneeID)
+	if err != nil {
+		return err
+	}
+
+	issueSubscriberFind := &api.IssueSubscriberFind{
+		IssueID: &issue.ID,
+	}
+	issueSubscriberRawList, err := s.IssueSubscriberService.FindIssueSubscriberList(ctx, issueSubscriberFind)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch subscriber list for issue %d", issue.ID)).SetInternal(err)
+	}
+	for _, issueSubscriberRaw := range issueSubscriberRawList {
+		issueSubscriber, err := s.composeIssueSubscriberRelationship(ctx, issueSubscriberRaw)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to fetch subscriber %d relationship for issue %d", issueSubscriberRaw.SubscriberID, issueSubscriberRaw.IssueID)).SetInternal(err)
+		}
+		issue.SubscriberList = append(issue.SubscriberList, issueSubscriber.Subscriber)
+	}
+
+	issue.Project, err = s.composeProjectByID(ctx, issue.ProjectID)
+	if err != nil {
+		return err
+	}
+
+	if issue.Pipeline == nil {
+		issue.Pipeline, err = s.composePipelineByID(ctx, issue.PipelineID)
+		if err != nil {
+			return err
+		}
+	} else {
+		if err := s.composePipelineRelationshipValidateOnly(ctx, issue.Pipeline); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Only allow Bot/Owner/DBA as the assignee, not Developer.
 func (s *Server) validateAssigneeRoleByID(ctx context.Context, assigneeID int) error {
 	assignee, err := s.PrincipalService.FindPrincipal(ctx, &api.PrincipalFind{
@@ -387,6 +439,9 @@ func (s *Server) createIssue(ctx context.Context, issueCreate *api.IssueCreate, 
 			PipelineID:  pipeline.ID,
 			Pipeline:    pipeline,
 		}
+		if err := s.composeIssueRelationshipValidateOnly(ctx, issue); err != nil {
+			return nil, err
+		}
 	} else {
 		issueCreate.CreatorID = creatorID
 		issueCreate.PipelineID = pipeline.ID
@@ -406,9 +461,9 @@ func (s *Server) createIssue(ctx context.Context, issueCreate *api.IssueCreate, 
 				return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to add subscriber %d after creating issue %d", subscriberID, issue.ID)).SetInternal(err)
 			}
 		}
-	}
-	if err := s.composeIssueRelationship(ctx, issue); err != nil {
-		return nil, err
+		if err := s.composeIssueRelationship(ctx, issue); err != nil {
+			return nil, err
+		}
 	}
 
 	// Return early if this is a validate only request.

--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -55,6 +55,35 @@ func (s *Server) composePipelineRelationship(ctx context.Context, pipeline *api.
 	return nil
 }
 
+func (s *Server) composePipelineRelationshipValidateOnly(ctx context.Context, pipeline *api.Pipeline) error {
+	var err error
+
+	pipeline.Creator, err = s.composePrincipalByID(ctx, pipeline.CreatorID)
+	if err != nil {
+		return err
+	}
+
+	pipeline.Updater, err = s.composePrincipalByID(ctx, pipeline.UpdaterID)
+	if err != nil {
+		return err
+	}
+
+	if pipeline.StageList == nil {
+		pipeline.StageList, err = s.composeStageListByPipelineID(ctx, pipeline.ID)
+		if err != nil {
+			return err
+		}
+	} else {
+		for _, stage := range pipeline.StageList {
+			if err := s.composeStageRelationshipValidateOnly(ctx, stage); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 // ScheduleNextTaskIfNeeded tries to schedule the next task if needed.
 // Returns nil if no task applicable can be scheduled
 func (s *Server) ScheduleNextTaskIfNeeded(ctx context.Context, pipeline *api.Pipeline) (*api.Task, error) {

--- a/server/stage.go
+++ b/server/stage.go
@@ -56,3 +56,36 @@ func (s *Server) composeStageRelationship(ctx context.Context, stage *api.Stage)
 
 	return nil
 }
+
+func (s *Server) composeStageRelationshipValidateOnly(ctx context.Context, stage *api.Stage) error {
+	var err error
+	stage.Creator, err = s.composePrincipalByID(ctx, stage.CreatorID)
+	if err != nil {
+		return err
+	}
+
+	stage.Updater, err = s.composePrincipalByID(ctx, stage.UpdaterID)
+	if err != nil {
+		return err
+	}
+
+	stage.Environment, err = s.composeEnvironmentByID(ctx, stage.EnvironmentID)
+	if err != nil {
+		return err
+	}
+
+	if stage.TaskList == nil {
+		stage.TaskList, err = s.composeTaskListByPipelineAndStageID(ctx, stage.PipelineID, stage.ID)
+		if err != nil {
+			return err
+		}
+	} else {
+		for _, task := range stage.TaskList {
+			if err := s.composeTaskRelationshipValidateOnly(ctx, task); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/server/task.go
+++ b/server/task.go
@@ -457,6 +457,64 @@ func (s *Server) composeTaskRelationship(ctx context.Context, task *api.Task) er
 	return nil
 }
 
+func (s *Server) composeTaskRelationshipValidateOnly(ctx context.Context, task *api.Task) error {
+	var err error
+
+	task.Creator, err = s.composePrincipalByID(ctx, task.CreatorID)
+	if err != nil {
+		return err
+	}
+
+	task.Updater, err = s.composePrincipalByID(ctx, task.UpdaterID)
+	if err != nil {
+		return err
+	}
+
+	for _, taskRun := range task.TaskRunList {
+		taskRun.Creator, err = s.composePrincipalByID(ctx, taskRun.CreatorID)
+		if err != nil {
+			return err
+		}
+
+		taskRun.Updater, err = s.composePrincipalByID(ctx, taskRun.UpdaterID)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, taskCheckRun := range task.TaskCheckRunList {
+		taskCheckRun.Creator, err = s.composePrincipalByID(ctx, taskCheckRun.CreatorID)
+		if err != nil {
+			return err
+		}
+
+		taskCheckRun.Updater, err = s.composePrincipalByID(ctx, taskCheckRun.UpdaterID)
+		if err != nil {
+			return err
+		}
+	}
+
+	task.Instance, err = s.composeInstanceByID(ctx, task.InstanceID)
+	if err != nil {
+		return err
+	}
+
+	if task.DatabaseID != nil {
+		databaseFind := &api.DatabaseFind{
+			ID: task.DatabaseID,
+		}
+		task.Database, err = s.composeDatabaseByFind(ctx, databaseFind)
+		if err != nil {
+			return err
+		}
+		if task.Database == nil {
+			return fmt.Errorf("database ID not found %v", task.DatabaseID)
+		}
+	}
+
+	return nil
+}
+
 func (s *Server) changeTaskStatus(ctx context.Context, task *api.Task, newStatus api.TaskStatus, updaterID int) (*api.Task, error) {
 	taskStatusPatch := &api.TaskStatusPatch{
 		ID:        task.ID,


### PR DESCRIPTION
This is intended as a pre-work of a refactoring later, which hopefully will decouple the logic of database object composition and validation.
